### PR TITLE
Pane/PaneView API changes

### DIFF
--- a/api.txt
+++ b/api.txt
@@ -392,7 +392,6 @@ PackageManager                                                 called packages a
   ::getAvailablePackageMetadata()                              0      0        0
 
 Pane                                                           called packages atom packages
-  ::getActiveEditor()                                          318    191      13
   ::activate()                                                 92     61       2
   ::destroyItem(item)                                          28     15       3
   ::getItems()                                                 18     14       2


### PR DESCRIPTION
This combines the Pane and PaneView APIs and removes some underused methods from the API.

One thing we might want to consider, move the split methods from Pane to
Workspace. I think conceptually it makes sense to split the Workspace rather
than a Pane. 
